### PR TITLE
Use namespace "ReLogger".

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ yarn add @cca-io/re-logger
 npm install @cca-io/re-logger
 ```
 
-Then add re-logger to the dependencies in your bsconfig.json, e.g.:
+Then add re-logger to the dependencies in your `bsconfig.json`, e.g.:
 
 ```
 {
@@ -23,11 +23,26 @@ Then add re-logger to the dependencies in your bsconfig.json, e.g.:
 }
 ```
 
+This library uses the namespace `ReLogger` to avoid conflicts if there is already a `Logger` module in your project. If that is not the case, you may want to open the `ReLogger` module globally in your `bsconfig.json`:
+
+```
+{
+  "name": "my-app",
+  ...
+  "bs-dependencies": ["reason-react", "@cca-io/re-logger"],
+  ...
+  "bsc-flags": ["-bs-super-errors", "-open ReLogger"],
+  ...
+}
+```
+
 ## Usage
 
 Example:
 
 ```reason
+open ReLogger; /* unless you already opened it globally in bsconfig.json */
+
 module Log = (val Logger.make(__MODULE__));
 
 Log.info("Starting");

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,6 @@
 {
-  "name": "@cca-io/re-logger",
+  "name": "re-logger",
+  "namespace": true,
   "sources": ["src"],
   "reason": {
     "react-jsx": 2

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "bsconfig.json"
   ],
   "keywords": [
-    "react",
     "reason",
     "reasonml",
     "log",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cca-io/re-logger",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "description": "Simple logger library for Reason/BuckleScript apps",
   "main": "src/Logger.bs.js",
   "repository": "https://github.com/cca-io/re-logger.git",


### PR DESCRIPTION
To avoid conflicts if there is already a "Logger" module in the project using ReLogger.

Version increased to 1.0.0 because of semantic versioning.